### PR TITLE
초시계·대답을 숨겨도 마우스가 제대로 감지되도록 수정

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // 초시계 숨기기
   document.getElementById('hideTimer').addEventListener('click', () => {
       executeCommand(`
-          Entry.engine.projectTimer.setX(-Number.MAX_VALUE);
+          Entry.engine.projectTimer.setX(-999);
           return "초시계가 숨겨졌습니다";
       `, (result) => {
           console.log(result);
@@ -57,7 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
   // 대답 숨기기
   document.getElementById('hideAnswer').addEventListener('click', () => {
       executeCommand(`
-          Entry.container.inputValue.setX(-Number.MAX_VALUE);
+          Entry.container.inputValue.setX(-999);
           return "대답 입력창이 숨겨졌습니다";
       `, (result) => {
           console.log(result);


### PR DESCRIPTION
https://github.com/llaa33219/Sweiser/blob/baf97ec5abdb12625d1d815ff6e2fa006ee659c8/popup.js#L47-L65
초시계·대답의 좌표를 -Number.MAX_VALUE로 설정 시, 엔트리 버그로 인해 보이지 않는 초시계·대답만 잡히는 버그가 있습니다.
그러므로 -Number.MAX_VALUE 대신 -999로 설정하도록 수정했습니다.